### PR TITLE
網頁攏傳http 200

### DIFF
--- a/server-side/itaigi/urls.py
+++ b/server-side/itaigi/urls.py
@@ -49,7 +49,7 @@ def pangboo(request, status, title, image):
 
 def kithann(request, exception=None):
     return pangboo(
-        request, status=404,
+        request, status=200,
         title='iTaigi 愛台語',
         image='https://g0v.github.io/itaigi/design/logo_og.png',
     )


### PR DESCRIPTION
## 狀況

Facebook後台警告資安政策lia̍h無，致使隱私相關政策無法度符合Facebook要求，無塊通使用Facebook login。

![圖片](https://user-images.githubusercontent.com/5996555/210697414-dfffcd94-7ff3-4b23-865b-8855c4838295.png)

## 原因

因為iTaigi是gh-page，single page，行為是主頁面以外status code是404。Facebook後台蜘蛛lia̍h資安政策網址，看著404，跳警告。

## 做法

網頁回傳200。Koh，別支處理gh-page轉做用Docker管理專案。