### PR TITLE
Celery beat mài用pid，docker restart才會正常運作

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - pgsql_data:/var/lib/postgresql/data
   celery_beat:
     build: ./
-    command: celery -A itaigi beat -l info
+    command: celery -A itaigi beat -l info --pidfile=
     environment:
       DEPLOY_HOST: ${DEPLOY_HOST:-itaigi.tw}
       SECRET_KEY: ${SECRET_KEY}


### PR DESCRIPTION
若無設定，docker restart後會
```
celery_beat_1  | ERROR: Pidfile (celerybeat.pid) already exists.
celery_beat_1  | Seems we're already running? (pid: 1)
```