### PR TITLE
意傳êGA，留新GA就好

### DIFF
--- a/server-side/templates/index.html
+++ b/server-side/templates/index.html
@@ -37,7 +37,6 @@
 
       gtag('config', 'G-PHLN815S8E');
       gtag('config', 'UA-49660899-2');
-      gtag('config', 'UA-78757122-12');
     </script>
   </head>
   <body>


### PR DESCRIPTION
## 需求

因為GA欲到期，就piànn-piànn--leh

## 變更時間

2023.6.14～2023.6.17

## 做法

Tsit-má有：

1. g0v時期ê pm5舊GA（資源ID UA-49660899-2）
2. 意傳舊GA（資源ID UA-78757122-12）
4. 意傳新GA4（資源ID是311164162，評估ID是G-PHLN815S8E）

另外，GA有自動生出GA4版本資源：

1. g0v時期ê pm5舊GA生出來--ê（資源ID 378297716）
4. 意傳舊GA生出來--ê（資源ID 375173971）

原資源若piànn，自動生出來--ê會自動piànn。

做法是先kā意傳舊GA piànn掉。

意傳GA：
![圖片](https://github.com/i3thuan5/itaigi/assets/5996555/3697f4e5-88e3-48cc-947c-79f0f03d196e)

pm5 GA：
![圖片](https://github.com/i3thuan5/itaigi/assets/5996555/5551f53f-5865-48c5-af0f-d7bc8d34d19b)

## 影響

### 機密

Bô。

### 完整

Bô。

### 可用
GA4 一ê就好，較清。

### 解決做法Github連結
這PR。

### 未來規劃

若新版有登入功能等等個資，才考慮kā pm5--ê hìnn-sak。

### 審查意見

